### PR TITLE
If a character that is determined to be a number is at the beginning, it is not determined to be JSON.

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,6 +109,14 @@ func (c *Checker) isJSON(s string) bool {
 	if serr := (*json.SyntaxError)(nil); errors.As(err, &serr) {
 		return false
 	}
+
+	if len(s) > 0 {
+		_, err := strconv.Atoi(s[0:1])
+		if err == nil {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/golden_test.go
+++ b/golden_test.go
@@ -29,17 +29,22 @@ func TestDiff(t *testing.T) {
 		got     any
 		hasDiff bool
 	}{
-		"string-nodiff":    {"hello", "hello", false},
-		"bytes-nodiff":     {"hello", []byte("hello"), false},
-		"reader-nodiff":    {"hello", strings.NewReader("hello"), false},
-		"json-nodiff":      {"{\"S\":\"hello\"}\n", struct{ S string }{S: "hello"}, false},
-		"marshaler-nodiff": {"hello", marshaler("hello"), false},
+		"string-nodiff":       {"hello", "hello", false},
+		"bytes-nodiff":        {"hello", []byte("hello"), false},
+		"reader-nodiff":       {"hello", strings.NewReader("hello"), false},
+		"json-nodiff":         {"{\"S\":\"hello\"}\n", struct{ S string }{S: "hello"}, false},
+		"marshaler-nodiff":    {"hello", marshaler("hello"), false},
+		"empty-nodiff":        {"", "", false},
+		"number-nodiff":       {"3", "3", false},
+		"number-start-nodiff": {"3 bytes", "3 bytes", false},
 
-		"string-diff":    {"Hello", "hello", true},
-		"bytes-diff":     {"Hello", []byte("hello"), true},
-		"reader-diff":    {"Hello", strings.NewReader("hello"), true},
-		"json-diff":      {"{\"S\":\"Hello\"}\n", struct{ S string }{S: "hello"}, true},
-		"marshaler-diff": {"Hello", marshaler("hello"), true},
+		"string-diff":       {"Hello", "hello", true},
+		"bytes-diff":        {"Hello", []byte("hello"), true},
+		"reader-diff":       {"Hello", strings.NewReader("hello"), true},
+		"json-diff":         {"{\"S\":\"Hello\"}\n", struct{ S string }{S: "hello"}, true},
+		"marshaler-diff":    {"Hello", marshaler("hello"), true},
+		"number-diff":       {"3", "4", true},
+		"number-start-diff": {"3 bytes", "4 bytes", true},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
Hi @tenntenn. Thank you for your NICE package!

Error occurs when attempting to decode a string with a character at the beginning that is determined to be a number.

```
json: cannot unmarshal number into Go value of type string
```

ref: https://go.dev/play/p/IcaYhYq31bj

This fix avoids the above error.

