### PR TITLE
Update Go version to 1.24.3

### DIFF
--- a/.github/workflows/testandvet.yml
+++ b/.github/workflows/testandvet.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.24.3
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tenntenn/golden
 
-go 1.18
+go 1.24.3
 
 require (
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
## Summary
- update required Go version to 1.24.3
- upgrade CI workflow to install Go 1.24.3

## Testing
- `go mod tidy` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*